### PR TITLE
Update Ministry for Culture and Heritage websites

### DIFF
--- a/public-sector-websites.csv
+++ b/public-sector-websites.csv
@@ -339,21 +339,22 @@ MidCentral District Health Board,midcentraldhb.govt.nz,Yes,District Health Board
 Midwifery Council of New Zealand,midwiferycouncil.health.nz,No,Regulatory Authority
 Mighty River Power Limited,mightyriver.co.nz,No,Mixed Ownership Model company
 Ministry for Culture and Heritage,28maoribattalion.org.nz,No,Public Service department
-Ministry for Culture and Heritage,anzac.govt.nz,No,Public Service department
+Ministry for Culture and Heritage,anzac.govt.nz,Yes,Public Service department
+Ministry for Culture and Heritage,canterburyearthquakememorial.co.nz,No,Public Service department
 Ministry for Culture and Heritage,dnzb.govt.nz,Yes,Public Service department
 Ministry for Culture and Heritage,firstworldwar.govt.nz,Yes,Public Service department
-Ministry for Culture and Heritage,goingdigital.co.nz,Yes,Public Service department
-Ministry for Culture and Heritage,heritageequip.govt.nz,Yes,Public Service department
+Ministry for Culture and Heritage,heritageequip.govt.nz,No,Public Service department
 Ministry for Culture and Heritage,mch.govt.nz,No,Public Service department
 Ministry for Culture and Heritage,ngatapuwae.govt.nz,No,Public Service department
 Ministry for Culture and Heritage,nzhistory.govt.nz,No,Public Service department
 Ministry for Culture and Heritage,protected-objects.govt.nz,Yes,Public Service department
-Ministry for Culture and Heritage,quakestories.govt.nz,No,Public Service department
+Ministry for Culture and Heritage,quakestories.govt.nz,Yes,Public Service department
 Ministry for Culture and Heritage,teara.govt.nz,No,Public Service department
-Ministry for Culture and Heritage,tiritiowaitangi.govt.nz,No,Public Service department
+Ministry for Culture and Heritage,tiritiowaitangi.govt.nz,Yes,Public Service department
 Ministry for Culture and Heritage,treatyofwaitangi.govt.nz,Yes,Public Service department
+Ministry for Culture and Heritage,tuia250.nz,Yes,Public Service department
 Ministry for Culture and Heritage,vietnamwar.govt.nz,No,Public Service department
-Ministry for Culture and Heritage,ww100.govt.nz,Yes,Public Service department
+Ministry for Culture and Heritage,ww100.govt.nz,No,Public Service department
 Ministry for Pacific Peoples ,mpia.govt.nz,No,Public Service department
 Ministry for Pacific Peoples ,mpp.govt.nz,Yes,Public Service department
 Ministry for Primary Industries,aquaculture.govt.nz,Yes,Public Service department


### PR DESCRIPTION
Please note that while goingdigital.co.nz is a registered domain, it was deregistered by the Ministry for Culture and Heritage. It is currently registered to an unaffiliated individual and so has been removed.